### PR TITLE
Fix Upgrading.md markup

### DIFF
--- a/Upgrading.md
+++ b/Upgrading.md
@@ -49,7 +49,7 @@ end
 ```
 
 
-** After:**
+**After:**
 
 ```erb
 <head>


### PR DESCRIPTION
I fixed `Upgrading.md`'s markup:

![2014-06-28 23 49 41](https://cloud.githubusercontent.com/assets/290782/3421037/7f452720-fed3-11e3-8462-db5566777867.png)
:arrow_down: 
![2014-06-28 23 49 51](https://cloud.githubusercontent.com/assets/290782/3421036/7f415b5e-fed3-11e3-9f4f-2ed430bc9498.png)

By the way, why `:css` option has gone?
I liked it. Are there something problem with it?
Ah, this question is just a interest :-)
