### PR TITLE
Fix testing Rails version

### DIFF
--- a/spec/railsapps/rails_41/Gemfile
+++ b/spec/railsapps/rails_41/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-gem 'rails', '4.0.0'
+gem 'rails', '4.1.0'
 gem 'sass-rails', '~> 4.0.0'
 
 gem 'roadie-rails', :path => '../../..'


### PR DESCRIPTION
`rails_41` app should be tested with Rails 4.1.0, not 4.0.0.
