### PR TITLE
Don't directly modify Sprockets::BundleAsset#source

### DIFF
--- a/lib/roadie/rails/asset_pipeline_provider.rb
+++ b/lib/roadie/rails/asset_pipeline_provider.rb
@@ -12,7 +12,7 @@ module Roadie
 
       def find_stylesheet(name)
         if (asset = @pipeline[normalize_asset_name name])
-          Stylesheet.new("#{asset.pathname} (live compiled)", asset.to_s)
+          Stylesheet.new("#{asset.pathname} (live compiled)", asset.to_s.dup)
         end
       end
 


### PR DESCRIPTION
Passing `asset.to_s` into Stylesheet causes Sprockets to serve that asset with a `Content-Length` greater than the size of the response, which hangs connections until they timeout with bytes remaining. This happened in our tests, and caused Chrome/Cucumber to hang for 30s on many steps, which increased our test run time by 10 minutes.

-----------------

In Sprocket `asset.to_s` directly returns a reference to the string of the asset's source (https://github.com/sstephenson/sprockets/blob/2.x/lib/sprockets/asset.rb#L112). That string is then modified inside of Stylesheet when it's parsed (https://github.com/Mange/roadie/blob/master/lib/roadie/stylesheet.rb#L67), removing whitespace, comments, etc. That directly modifies Sprockets' asset in memory, which is then cached for future requests.

Sprockets  2.x (and likely in 3.x) stores the length of the asset on asset init (https://github.com/sstephenson/sprockets/blob/2.x/lib/sprockets/bundled_asset.rb#L29), and that length is cached while the server is running.

Combining those two together, we get a situation where Sprockets has a cached `BundledAsset` that has a length that includes whitespace/comments/etc, but a source that does not. The stored length is what's used to set the `Content-Length` header when serving the asset (https://github.com/sstephenson/sprockets/blob/2.x/lib/sprockets/server.rb#L193). At the same time, the response to the client is set as the `source` string -- which has been modified in-memory by roadie. This causes the mismatch between `Content-Length` and the response.

-----------------

Is this the sort of thing you'd like to have a test case for? If so, any guidance on a good way to go about it? Reproducing it exercises rather a lot of the stack.