### PR TITLE
remove asset digest

### DIFF
--- a/lib/roadie/rails/asset_pipeline_provider.rb
+++ b/lib/roadie/rails/asset_pipeline_provider.rb
@@ -24,7 +24,7 @@ module Roadie
       end
 
       def remove_asset_digest(path)
-        path.gsub /-[a-z0-9]{32}/, ''
+        path.gsub /-[a-z0-9]{32}\./, '.'
       end
 
       def remove_asset_prefix(path)

--- a/lib/roadie/rails/asset_pipeline_provider.rb
+++ b/lib/roadie/rails/asset_pipeline_provider.rb
@@ -19,8 +19,7 @@ module Roadie
       private
       def normalize_asset_name(href)
         res = remove_asset_prefix href.split('?').first
-        res = remove_asset_digest res
-        res
+        remove_asset_digest res
       end
 
       def remove_asset_digest(path)

--- a/lib/roadie/rails/asset_pipeline_provider.rb
+++ b/lib/roadie/rails/asset_pipeline_provider.rb
@@ -18,7 +18,13 @@ module Roadie
 
       private
       def normalize_asset_name(href)
-        remove_asset_prefix href.split('?').first
+        res = remove_asset_prefix href.split('?').first
+        res = remove_asset_digest res
+        res
+      end
+
+      def remove_asset_digest(path)
+        path.gsub /-[a-z0-9]{32}/, ''
       end
 
       def remove_asset_prefix(path)

--- a/spec/lib/roadie/rails/asset_pipeline_provider_spec.rb
+++ b/spec/lib/roadie/rails/asset_pipeline_provider_spec.rb
@@ -35,6 +35,12 @@ module Roadie
           expect(provider.find_stylesheet("/assets/good.css?body=1")).not_to be_nil
         end
 
+        it "ignores asset digest" do
+          pipeline.add_asset "good.css", "good.css.scss", ""
+          provider = AssetPipelineProvider.new(pipeline)
+          expect(provider.find_stylesheet("/assets/good-a1b605c3ff85456f0bf7bbbe3f59030a.css?body=1")).not_to be_nil
+        end
+
         it "supports stylesheets inside subdirectories" do
           pipeline.add_asset "sub/deep.css", "/path/to/sub/deep.css.scss", "body { color: green; }"
           provider = AssetPipelineProvider.new(pipeline)

--- a/spec/lib/roadie/rails/asset_pipeline_provider_spec.rb
+++ b/spec/lib/roadie/rails/asset_pipeline_provider_spec.rb
@@ -38,7 +38,7 @@ module Roadie
         it "ignores asset digest" do
           pipeline.add_asset "good.css", "good.css.scss", ""
           provider = AssetPipelineProvider.new(pipeline)
-          expect(provider.find_stylesheet("/assets/good-a1b605c3ff85456f0bf7bbbe3f59030a.css?body=1")).not_to be_nil
+          expect(provider.find_stylesheet("/assets/good-a1b605c3ff85456f0bf7bbbe3f59030a.css")).not_to be_nil
         end
 
         it "supports stylesheets inside subdirectories" do


### PR DESCRIPTION
Make sure to remove all digests from asset paths so that the assets can be found by the asset pipeline.