### PR TITLE
Depend on railties instead of rails

### DIFF
--- a/roadie-rails.gemspec
+++ b/roadie-rails.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "roadie", "~> 3.0"
-  spec.add_dependency "rails", ">= 3.0", "< 4.3"
+  spec.add_dependency "railties", ">= 3.0", "< 4.3"
 
+  spec.add_development_dependency "rails", ">= 3.0", "< 4.3"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-rails"


### PR DESCRIPTION
As some projects don't use all of Rails (e.g. ORMs other than ActiveRecord), this change modifies the runtime dependencies to be on `railties` rather than `rails` itself.  `rails` is added as a development dependency to ensure tests can still be executed.