### PR TITLE
Forced delivery

### DIFF
--- a/lib/roadie/rails/inline_on_delivery.rb
+++ b/lib/roadie/rails/inline_on_delivery.rb
@@ -7,10 +7,21 @@ module Roadie
       attr_accessor :roadie_options
 
       def deliver
+        inline_styles
+        super
+      end
+
+      def deliver!
+        inline_styles
+        super
+      end
+
+      private
+
+      def inline_styles
         if (options = roadie_options)
           MailInliner.new(self, options).execute
         end
-        super
       end
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -22,9 +22,7 @@ describe "Integrations" do
     describe "with #{app}" do
       before { app.reset }
 
-      it "inlines styles for multipart emails" do
-        email = app.read_email(:normal_email)
-
+      def validate_email(app, email)
         expect(email.to).to eq(['example@example.org'])
         expect(email.from).to eq(['john@example.com'])
         expect(email).to have(2).parts
@@ -56,38 +54,16 @@ describe "Integrations" do
         email.deliver
       end
 
+      it "inlines styles for multipart emails" do
+        validate_email app, app.read_email(:normal_email)
+      end
+
       it "automatically inlines styles with automatic mailer" do
-        email = app.read_delivered_email(:normal_email)
+        validate_email app, app.read_delivered_email(:normal_email)
+      end
 
-        expect(email.to).to eq(['example@example.org'])
-        expect(email.from).to eq(['john@example.com'])
-        expect(email).to have(2).parts
-
-        expect(email.text_part.body.decoded).not_to match(/<.*>/)
-
-        html = email.html_part.body.decoded
-        expect(html).to include '<!DOCTYPE'
-        expect(html).to include '<head'
-
-        document = parse_html_in_email(email)
-        expect(document).to have_selector('body h1')
-
-        if app.digested?
-          if app.sprockets3?
-            expected_image_url = 'https://example.app.org/assets/rails-322506f9917889126e81df2833a6eecdf2e394658d53dad347e9882dd4dbf28e.png'
-          else
-            expected_image_url = 'https://example.app.org/assets/rails-231a680f23887d9dd70710ea5efd3c62.png'
-          end
-        elsif app.using_asset_pipeline?
-          expected_image_url = 'https://example.app.org/assets/rails.png'
-        else
-          expected_image_url = 'https://example.app.org/images/rails.png'
-        end
-        expect(document).to have_styling('background' => "url(#{expected_image_url})").at_selector('.image')
-
-        # If we deliver mails we can catch weird problems with headers being invalid
-        email.delivery_method :test
-        email.deliver
+      it "automatically inlines styles with automatic mailer and forced delivery" do
+        validate_email app, app.read_delivered_email(:normal_email, force_delivery: true)
       end
 
       it "inlines no styles when roadie_options are nil" do

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -20,8 +20,9 @@ class RailsApp
     Mail.read_from_string(result)
   end
 
-  def read_delivered_email(mail_name)
-    result = run("mail = AutoMailer.#{mail_name}; mail.delivery_method(:test); mail.deliver; puts mail.to_s")
+  def read_delivered_email(mail_name, options = {})
+    deliver = options[:force_delivery] ? "deliver!" : "deliver" 
+    result = run("mail = AutoMailer.#{mail_name}; mail.delivery_method(:test); mail.#{deliver}; puts mail.to_s")
     raise "No email returned. Did the rails application crash?" if result.strip.empty?
     Mail.read_from_string(result)
   end


### PR DESCRIPTION
When I tried using roadie-rails in combination with a bang version of the Rails mailer deliver methods to skip raising exceptions the email styles were not inlined.

```ruby
# Did not inline styles like deliver_now
UserMailer.welcome(user: user).deliver_now!
```

I propose to intercept the `deliver!` message on `Mail` instances as well as the `deliver` message to trigger the automatic inlining of styles.

I restructured the integration test a bit to avoid another copy of the email validation code.