### PR TITLE
Fix #roadie_email

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 [full changelog](https://github.com/Mange/roadie-rails/compare/v1.3.0...master)
 
 * Add support for Ruby 2.5.
+* Fix arity of `Roadie::Rails::Mailer#roadie_mail` - [Adrian Lehmann (ownadi)](https://github.com/ownadi)
 
 ### 1.3.0
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ class MyOtherMailer
   include Roadie::Rails::Mailer
 
   def some_mail(user)
-    roadie_email {to: "foo@example.com"}, roadie_options_for(user)
+    roadie_mail {to: "foo@example.com"}, roadie_options_for(user)
   end
 
   private

--- a/lib/roadie/rails/mailer.rb
+++ b/lib/roadie/rails/mailer.rb
@@ -1,9 +1,9 @@
 module Roadie
   module Rails
     module Mailer
-      def roadie_mail(options = {}, custom_roadie_options = nil, &block)
+      def roadie_mail(options = {}, final_roadie_options = roadie_options, &block)
         email = mail(options, &block)
-        MailInliner.new(email, custom_roadie_options || roadie_options).execute
+        MailInliner.new(email, final_roadie_options).execute
       end
 
       def roadie_options

--- a/lib/roadie/rails/mailer.rb
+++ b/lib/roadie/rails/mailer.rb
@@ -1,9 +1,9 @@
 module Roadie
   module Rails
     module Mailer
-      def roadie_mail(options = {}, &block)
+      def roadie_mail(options = {}, custom_roadie_options = nil, &block)
         email = mail(options, &block)
-        MailInliner.new(email, roadie_options).execute
+        MailInliner.new(email, custom_roadie_options || roadie_options).execute
       end
 
       def roadie_options

--- a/roadie-rails.gemspec
+++ b/roadie-rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "railties", ">= 3.0", "< 5.3"
 
   spec.add_development_dependency "rails", ">= 4.2", "< 5.3"
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "rspec-collection_matchers"

--- a/roadie-rails.gemspec
+++ b/roadie-rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "railties", ">= 3.0", "< 5.3"
 
   spec.add_development_dependency "rails", ">= 4.2", "< 5.3"
-  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "bundler", "~> 1"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "rspec-collection_matchers"

--- a/spec/lib/roadie/rails/mailer_spec.rb
+++ b/spec/lib/roadie/rails/mailer_spec.rb
@@ -45,6 +45,14 @@ module Roadie
           instance.roadie_mail(some: "option") { }
         end
 
+        it "allows to override roadie options" do
+          custom_options = { foo: 'bar' }
+          inliner = double "Inliner"
+          expect(MailInliner).to receive(:new).with(email, custom_options).and_return inliner
+          expect(inliner).to receive(:execute).and_return "inlined email"
+          expect(instance.roadie_mail({ }, custom_options)).to eq("inlined email")
+        end
+
         it "inlines the email" do
           inliner = double "Inliner"
           expect(MailInliner).to receive(:new).with(email, instance_of(Options)).and_return inliner


### PR DESCRIPTION
According to the readme, one should be able to configure roadie by passing options to the second argument of #roadie_mail. This method accepts only one argument though.