### PR TITLE
Relax roadie dependency to allow v4.x

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 [full changelog](https://github.com/Mange/roadie-rails/compare/v2.1.0...master)
 
+* Relax Roadie dependency to allow v4.x
 * Updated embedded Rails apps (used in tests) to work with new Sprockets 4.
 * Updated Rubocop config to work with newer Rubocop versions.
 

--- a/roadie-rails.gemspec
+++ b/roadie-rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "railties", ">= 5.1", "< 6.1"
-  spec.add_dependency "roadie", "~> 3.1"
+  spec.add_dependency "roadie", ">= 3.1", "< 5.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rails", ">= 5.1", "< 6.1"


### PR DESCRIPTION
Allow usage with v4.x of roadie gem