### PR TITLE
Relax dependency requirement for Rails to support 6.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 [full changelog](https://github.com/Mange/roadie-rails/compare/v2.1.1...master)
 
-* Nothing yet.
+- Support Rails 6.1 [@afomera](https://github.com/afomera)
 
 ### 2.1.1
 

--- a/roadie-rails.gemspec
+++ b/roadie-rails.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = %w[README.md Changelog.md LICENSE.txt]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", ">= 5.1", "< 6.1"
+  spec.add_dependency "railties", ">= 5.1", "< 6.2"
   spec.add_dependency "roadie", ">= 3.1", "< 5.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rails", ">= 5.1", "< 6.1"
+  spec.add_development_dependency "rails", ">= 5.1", "< 6.2"
   spec.add_development_dependency "rspec", "~> 3.8"
   spec.add_development_dependency "rspec-collection_matchers"
   spec.add_development_dependency "rspec-rails"


### PR DESCRIPTION
Hi @Mange,

Thanks for the work you've done for Roadie & roadie-rails!

We've been using it @podia and we've been running 6.1's release candidates with no known issues with Roadie/Roadie-rails.

We'd like to bump the Gemspec to support the official 6.1 release this upcoming week (it's expected unless issues rise up).