### PR TITLE
Loosen Rails requirement to allow for bundling with Rails 7

### DIFF
--- a/roadie-rails.gemspec
+++ b/roadie-rails.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "roadie", ">= 3.1", "< 5.0"
 
   spec.add_development_dependency "bundler", "~> 2.2"
-  spec.add_development_dependency "rails", ">= 5.1", "< 7.0"
+  spec.add_development_dependency "rails", ">= 5.1", "< 8.0"
   spec.add_development_dependency "rspec", "~> 3.10"
   spec.add_development_dependency "rspec-collection_matchers"
   spec.add_development_dependency "rspec-rails"


### PR DESCRIPTION
Looks like in the past commit we added tests for allowing Rails 7.

However, when one tries to bundle a Rails 7 app, the gemspec blocks the resolution.

This is the first step to getting apps to bundle.

If there is work to be done to get this fully mergable/gem cuttable, I'm happy to take some direction to get this PR ready to go.

Thanks for roadie-rails!