### PR TITLE
Loosen Rails requirement to allow for bundling with Rails 7

### DIFF
--- a/roadie-rails.gemspec
+++ b/roadie-rails.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = %w[README.md Changelog.md LICENSE.txt]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", ">= 5.1", "< 7.0"
+  spec.add_dependency "railties", ">= 5.1", "< 7.1"
   spec.add_dependency "roadie", ">= 3.1", "< 5.0"
 
   spec.add_development_dependency "bundler", "~> 2.2"
-  spec.add_development_dependency "rails", ">= 5.1", "< 7.0"
+  spec.add_development_dependency "rails", ">= 5.1", "< 7.1"
   spec.add_development_dependency "rspec", "~> 3.10"
   spec.add_development_dependency "rspec-collection_matchers"
   spec.add_development_dependency "rspec-rails"


### PR DESCRIPTION
I copied #99 and amended the change to `rails < 7.1` and `railties < 7.1`, I kept @maxwell as author 🙂 

Tested in a bundle with Rails 7.0 and:
```ruby
gem 'roadie-rails', github: 'davidwessman/roadie-rails', branch: 'loosen-rails-version-requirement'
```