### PR TITLE
Github Actions: Adds pull_request and ruby 3.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,12 @@
 name: Main
 on:
   push:
+    branches:
+      - main
+      - master
+
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   base:
@@ -9,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6.9", "2.7.2", "3.0.3"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
 
     steps:
       - name: Checkout code

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,11 @@
 
 [full changelog](https://github.com/Mange/roadie-rails/compare/v2.3.0...master)
 
-* Nothing yet.
+Development changes:
+
+* Replace Travis CI with Github CI.
+  - Ruby versions: 2.6, 2.7, 3.0, 3.1
+  - Rails versions: 5.1, 5.2, 6.0, 6.1, 7.0
 
 ### 2.3.0
 

--- a/README.md
+++ b/README.md
@@ -284,12 +284,15 @@ Tested with Github Actions on multiple Ruby and Rails versions:
   * MRI 2.6
   * MRI 2.7
   * MRI 3.0
+  * MRI 3.1
 * Rails
   * 5.1
   * 5.2
   * 6.0
+  * 6.1
   * 7.0
 
+Please note that [all Rails-versions are not compatible with all Ruby-versions](https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html).
 Let me know if you want any other combination supported officially.
 
 ### Versioning ###
@@ -316,7 +319,7 @@ After running `rake` for the first time and you want to keep running tests witho
 
 (The MIT License)
 
-Copyright © 2013-2021 [Magnus Bergmark](https://github.com/Mange) <magnus.bergmark@gmail.com>, et. al.
+Copyright © 2013-2022 [Magnus Bergmark](https://github.com/Mange) <magnus.bergmark@gmail.com>, et. al.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ‘Software’), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -10,11 +10,11 @@ describe "Integrations" do
   end
 
   rails_apps = [
-    RailsApp.new("Rails 5.1.0", "rails_51", max_ruby_version: "2.7.5"),
-    RailsApp.new("Rails 5.2.0", "rails_52", max_ruby_version: "2.7.5"),
-    RailsApp.new("Rails 6.0.0", "rails_60"),
-    RailsApp.new("Rails 6.1.4.4", "rails_61"),
-    RailsApp.new("Rails 7.0.0", "rails_70", min_ruby_version: "2.7.0")
+    RailsApp.new("Rails 5.1", "rails_51", max_ruby_version: "2.7"),
+    RailsApp.new("Rails 5.2", "rails_52", max_ruby_version: "2.7"),
+    RailsApp.new("Rails 6.0", "rails_60", max_ruby_version: "3.0"),
+    RailsApp.new("Rails 6.1", "rails_61", max_ruby_version: "3.0"),
+    RailsApp.new("Rails 7.0", "rails_70", min_ruby_version: "2.7")
   ]
 
   shared_examples "generates valid email" do |message|

--- a/spec/railsapps/rails_52/Gemfile
+++ b/spec/railsapps/rails_52/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.2.0.rc1"
+gem "rails", "~> 5.2.0"
 gem "sass-rails"
 gem "sprockets-rails"
 gem "listen"

--- a/spec/railsapps/rails_60/Gemfile
+++ b/spec/railsapps/rails_60/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-gem 'rails', '~> 6.0.0.beta3'
+gem 'rails', '~> 6.0.0'
 gem 'sass-rails'
 gem 'sprockets-rails'
 gem 'listen'

--- a/spec/railsapps/rails_61/Gemfile
+++ b/spec/railsapps/rails_61/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 6.1.4', '>= 6.1.4.4'
+gem 'rails', '~> 6.1.0'
 
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'listen'


### PR DESCRIPTION
- Adds `pull_request` to Github Action to run tests on PR where the
  branch is on a fork.
- Adds Ruby 3.1 to testing matrix, but only for Rails 7.
- Refactors versions from e.g. Ruby 2.7.4 -> 2.7 to test new minor versions.
