### PR TITLE
Add code formatter: standardrb

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,3 +33,11 @@ jobs:
         run: rake
 
       - uses: codecov/codecov-action@v2
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: standardrb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: amoeba/standardrb-action@v2

--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -1,0 +1,16 @@
+---
+include:
+  - "**/*.rb"
+exclude:
+  - spec/**/*
+  - test/**/*
+  - vendor/**/*
+  - ".bundle/**/*"
+require: []
+domains: []
+plugins:
+  - solargraph-standardrb
+reporters:
+  - standardrb
+require_paths: []
+max_files: 5000

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,7 @@ gemspec
 # Added here so it does not show up on the Gemspec; I only want it for CI builds
 gem "simplecov", group: :test, require: false
 gem "simplecov-cobertura", group: :test, require: false
+
+# Not actually required to run the tests for the gem, but a real convenience
+# for local development.
+gem "standard", group: [:test, :development], require: false

--- a/lib/roadie/rails/asset_pipeline_provider.rb
+++ b/lib/roadie/rails/asset_pipeline_provider.rb
@@ -10,7 +10,7 @@ module Roadie
         unless pipeline
           raise(
             ArgumentError,
-            "You need to pass a pipeline to initialize AssetPipelineProvider",
+            "You need to pass a pipeline to initialize AssetPipelineProvider"
           )
         end
 
@@ -25,6 +25,7 @@ module Roadie
       end
 
       private
+
       def filename(asset)
         if asset.respond_to?(:filename) # sprockets 4 or later
           asset.filename

--- a/lib/roadie/rails/mail_inliner.rb
+++ b/lib/roadie/rails/mail_inliner.rb
@@ -12,13 +12,14 @@ module Roadie
 
       def execute
         if options
-          improve_body if email.content_type =~ %r{^text/html}
+          improve_body if %r{^text/html}.match?(email.content_type)
           improve_html_part(email.html_part) if email.html_part
         end
         email
       end
 
       private
+
       def improve_body
         email.body = transform_html(email.body.decoded)
       end

--- a/lib/roadie/rails/options.rb
+++ b/lib/roadie/rails/options.rb
@@ -18,7 +18,7 @@ module Roadie
         :url_options,
         :before_transformation,
         :after_transformation,
-        :keep_uninlinable_css,
+        :keep_uninlinable_css
       )
 
       def initialize(options = {})
@@ -75,7 +75,7 @@ module Roadie
         dup.combine! options
       end
 
-      def combine!(options) # rubocop:disable Metrics/MethodLength
+      def combine!(options)
         %i[after_transformation before_transformation].each do |name|
           self[name] = Utils.combine_callable(self[name], options[name])
         end
@@ -90,7 +90,7 @@ module Roadie
 
         self.url_options = Utils.combine_hash(
           url_options,
-          options[:url_options],
+          options[:url_options]
         )
 
         self
@@ -113,13 +113,14 @@ module Roadie
       end
 
       private
+
       def complain_about_unknown_keys(keys)
         invalid_keys = keys - ATTRIBUTE_NAMES
         unless invalid_keys.empty?
           raise(
             ArgumentError,
             "Unknown configuration parameters: #{invalid_keys}",
-            caller(1),
+            caller(1)
           )
         end
       end

--- a/lib/roadie/rails/railtie.rb
+++ b/lib/roadie/rails/railtie.rb
@@ -9,7 +9,7 @@ module Roadie
 
       initializer "roadie-rails.setup" do |app|
         config.roadie.asset_providers = [
-          Roadie::FilesystemProvider.new(::Rails.root.join("public").to_s),
+          Roadie::FilesystemProvider.new(::Rails.root.join("public").to_s)
         ]
 
         if app.config.respond_to?(:assets) && app.config.assets

--- a/lib/roadie/rails/utils.rb
+++ b/lib/roadie/rails/utils.rb
@@ -4,6 +4,7 @@ module Roadie
   module Rails
     module Utils
       module_function
+
       # Combine two hashes, or return the non-nil hash if either is nil.
       # Returns nil if both are nil.
       def combine_hash(first, second)

--- a/roadie-rails.gemspec
+++ b/roadie-rails.gemspec
@@ -5,20 +5,20 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "roadie/rails/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "roadie-rails"
-  spec.version       = Roadie::Rails::VERSION
-  spec.authors       = ["Magnus Bergmark"]
-  spec.email         = ["magnus.bergmark@gmail.com"]
-  spec.homepage      = "http://github.com/Mange/roadie-rails"
-  spec.summary       = "Making HTML emails comfortable for the Rails rockstars"
-  spec.description   = "Hooks Roadie into your Rails application to help with email generation."
-  spec.license       = "MIT"
+  spec.name = "roadie-rails"
+  spec.version = Roadie::Rails::VERSION
+  spec.authors = ["Magnus Bergmark"]
+  spec.email = ["magnus.bergmark@gmail.com"]
+  spec.homepage = "http://github.com/Mange/roadie-rails"
+  spec.summary = "Making HTML emails comfortable for the Rails rockstars"
+  spec.description = "Hooks Roadie into your Rails application to help with email generation."
+  spec.license = "MIT"
 
   spec.required_ruby_version = ">= 2.5"
 
-  spec.files         = `git ls-files | grep -v ^spec`.split($INPUT_RECORD_SEPARATOR)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files = `git ls-files | grep -v ^spec`.split($INPUT_RECORD_SEPARATOR)
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.extra_rdoc_files = %w[README.md Changelog.md LICENSE.txt]
   spec.require_paths = ["lib"]
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -36,7 +36,7 @@ describe "Integrations" do
         "https://example.app.org/assets/rails-cd95a25e70dfe61add5a96e11d3fee0f29e9ba2b05099723d57bba7dfa725c8a.png"
 
       expect(document).to have_styling(
-        "background" => "url(#{expected_image_url})",
+        "background" => "url(#{expected_image_url})"
       ).at_selector(".image")
 
       # If we deliver mails we can catch weird problems with headers being
@@ -60,7 +60,7 @@ describe "Integrations" do
 
       include_examples(
         "generates valid email",
-        "with automatic mailer and forced delivery",
+        "with automatic mailer and forced delivery"
       ) do
         let(:email) do
           app.read_delivered_email(:normal_email, force_delivery: true)
@@ -88,7 +88,7 @@ describe "Integrations" do
           %w[
             Roadie::FilesystemProvider
             Roadie::Rails::AssetPipelineProvider
-          ],
+          ]
         )
       end
     end

--- a/spec/lib/roadie/rails/asset_pipeline_provider_spec.rb
+++ b/spec/lib/roadie/rails/asset_pipeline_provider_spec.rb
@@ -17,7 +17,7 @@ module Roadie
       it_behaves_like(
         "roadie asset provider",
         valid_name: "existing.css",
-        invalid_name: "bad.css",
+        invalid_name: "bad.css"
       ) do
         subject { AssetPipelineProvider.new(pipeline) }
         before do
@@ -30,13 +30,13 @@ module Roadie
           pipeline.add_asset(
             "good.css",
             "/path/to/good.css.scss",
-            "body { color: red; }",
+            "body { color: red; }"
           )
           provider = AssetPipelineProvider.new(pipeline)
 
           stylesheet = provider.find_stylesheet("good.css")
           expect(stylesheet.name).to eq(
-            "/path/to/good.css.scss (live compiled)",
+            "/path/to/good.css.scss (live compiled)"
           )
           expect(stylesheet.to_s).to eq("body{color:red}")
         end
@@ -45,7 +45,7 @@ module Roadie
           pipeline.add_asset "good.css", "good.css.scss", ""
           provider = AssetPipelineProvider.new(pipeline)
           expect(
-            provider.find_stylesheet("/assets/good.css?body=1"),
+            provider.find_stylesheet("/assets/good.css?body=1")
           ).not_to be_nil
         end
 
@@ -56,16 +56,16 @@ module Roadie
           # Old digest length
           expect(
             provider.find_stylesheet(
-              "/assets/good-a1b605c3ff85456f0bf7bbbe3f59030a.css",
-            ),
+              "/assets/good-a1b605c3ff85456f0bf7bbbe3f59030a.css"
+            )
           ).not_to be_nil
 
           # New digest length
           expect(
             provider.find_stylesheet(
               "/assets/good-00acbfe0213dff8c5ba7232e3dabb3584c9e216bdb" \
-                "489f69d7aa20e0e101f3e6.css",
-            ),
+                "489f69d7aa20e0e101f3e6.css"
+            )
           ).not_to be_nil
         end
 
@@ -73,13 +73,13 @@ module Roadie
           pipeline.add_asset(
             "vendor-a1b605c3ff85456f0bf7bbbe3f59030a.css",
             "vendor-a1b605c3ff85456f0bf7bbbe3f59030a.css",
-            "",
+            ""
           )
           provider = AssetPipelineProvider.new(pipeline)
           expect(
             provider.find_stylesheet(
-              "/assets/vendor-a1b605c3ff85456f0bf7bbbe3f59030a.css",
-            ),
+              "/assets/vendor-a1b605c3ff85456f0bf7bbbe3f59030a.css"
+            )
           ).not_to be_nil
         end
 
@@ -87,36 +87,16 @@ module Roadie
           pipeline.add_asset(
             "sub/deep.css",
             "/path/to/sub/deep.css.scss",
-            "body { color: green; }",
+            "body { color: green; }"
           )
           provider = AssetPipelineProvider.new(pipeline)
 
           stylesheet = provider.find_stylesheet("sub/deep.css")
           expect(stylesheet.name).to eq(
-            "/path/to/sub/deep.css.scss (live compiled)",
+            "/path/to/sub/deep.css.scss (live compiled)"
           )
           expect(stylesheet.to_s).to eq("body{color:green}")
         end
-      end
-
-      class FakePipeline
-        # Interface
-        def [](name)
-          @files.find { |file| file.matching_name == name }
-        end
-
-        ### Test helpers ###
-
-        def initialize
-          @files = []
-        end
-
-        def add_asset(matching_name, path, content)
-          @files << AssetFile.new(matching_name, path, content)
-        end
-
-        AssetFile = Struct.new(:matching_name, :pathname, :to_s)
-        private_constant :AssetFile
       end
     end
   end

--- a/spec/lib/roadie/rails/inline_on_delivery_spec.rb
+++ b/spec/lib/roadie/rails/inline_on_delivery_spec.rb
@@ -6,20 +6,6 @@ require "mail"
 module Roadie
   module Rails
     describe InlineOnDelivery do
-      class FakeMail < Mail::Message
-        def delivered?
-          @delivered
-        end
-
-        def deliver
-          @delivered = true
-        end
-
-        def deliver!
-          @delivered = true
-        end
-      end
-
       it "inlines on #delivery" do
         inliner = instance_double(MailInliner, execute: nil)
         options = instance_double(Options)

--- a/spec/lib/roadie/rails/mail_inliner_spec.rb
+++ b/spec/lib/roadie/rails/mail_inliner_spec.rb
@@ -54,7 +54,7 @@ module Roadie
           expect(email.body.decoded).to eq("transformed HTML")
           expect(DocumentBuilder).to have_received(:build).with(
             html,
-            instance_of(Options),
+            instance_of(Options)
           )
         end
 
@@ -87,7 +87,7 @@ module Roadie
           expect(email.html_part.body.decoded).to eq("transformed HTML")
           expect(DocumentBuilder).to have_received(:build).with(
             html,
-            instance_of(Options),
+            instance_of(Options)
           )
         end
 

--- a/spec/lib/roadie/rails/mailer_spec.rb
+++ b/spec/lib/roadie/rails/mailer_spec.rb
@@ -59,7 +59,7 @@ module Roadie
 
           expect(MailInliner).to have_received(:new).with(
             email,
-            instance_of(Options),
+            instance_of(Options)
           )
           expect(inliner).to have_received(:execute)
         end
@@ -69,7 +69,7 @@ module Roadie
           allow(MailInliner).to receive(:new).and_return(inliner)
 
           expect(
-            instance.roadie_mail({}, foo: "bar"),
+            instance.roadie_mail({}, foo: "bar")
           ).to eq("inlined email")
 
           expect(MailInliner).to have_received(:new).with(email, foo: "bar")

--- a/spec/lib/roadie/rails/options_spec.rb
+++ b/spec/lib/roadie/rails/options_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 require "ostruct"
 
 module Roadie
-  module Rails # rubocop:disable Metrics/ModuleLength
+  module Rails
     describe Options do
       it "raises errors when constructed with unknown options" do
         expect {
@@ -122,7 +122,7 @@ module Roadie
         let(:valid_value) { -> {} }
         let(:other_valid_value) { -> {} }
 
-        def expect_combinated_value(value) # rubocop:disable Metrics/AbcSize
+        def expect_combinated_value(value)
           allow(valid_value).to receive(:call).and_return 1
           allow(other_valid_value).to receive(:call).and_return 2
 
@@ -137,7 +137,7 @@ module Roadie
         let(:valid_value) { -> {} }
         let(:other_valid_value) { -> {} }
 
-        def expect_combinated_value(value) # rubocop:disable Metrics/AbcSize
+        def expect_combinated_value(value)
           allow(valid_value).to receive(:call).and_return 1
           allow(other_valid_value).to receive(:call).and_return 2
 

--- a/spec/lib/roadie/rails/railtie_spec.rb
+++ b/spec/lib/roadie/rails/railtie_spec.rb
@@ -17,8 +17,8 @@ module Roadie
       def run_initializer
         # Hack to make the Railtie able to be initialized again
         # Railties are global state, after all, stored on the classes.
-        Railtie.instance_variable_set("@instance", nil) # Embrace me, Cthulhu!
-        Railtie.instance_variable_set("@ran", nil)
+        Railtie.instance_variable_set(:@instance, nil) # Embrace me, Cthulhu!
+        Railtie.instance_variable_set(:@ran, nil)
         Railtie.run_initializers :default, rails_application
       end
 

--- a/spec/railsapps/rails_51/app/mailers/auto_mailer.rb
+++ b/spec/railsapps/rails_51/app/mailers/auto_mailer.rb
@@ -14,8 +14,9 @@ class AutoMailer < ActionMailer::Base
   end
 
   private
+
   def roadie_options
-    unless action_name =~ /disabled/
+    unless /disabled/.match?(action_name)
       super.combine(url_options: {protocol: "https"})
     end
   end

--- a/spec/railsapps/rails_51/app/mailers/mailer.rb
+++ b/spec/railsapps/rails_51/app/mailers/mailer.rb
@@ -13,6 +13,7 @@ class Mailer < ActionMailer::Base
   end
 
   private
+
   def roadie_options
     super.combine(url_options: {protocol: "https"})
   end

--- a/spec/railsapps/rails_51/config/environments/production.rb
+++ b/spec/railsapps/rails_51/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
   # Disable serving static files from the `/public` folder by default since
@@ -49,7 +49,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -78,7 +78,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/spec/railsapps/rails_51/config/environments/test.rb
+++ b/spec/railsapps/rails_51/config/environments/test.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.

--- a/spec/railsapps/rails_51/config/initializers/assets.rb
+++ b/spec/railsapps/rails_51/config/initializers/assets.rb
@@ -10,4 +10,4 @@ Rails.application.config.assets.version = "1.0"
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( email.css )
+Rails.application.config.assets.precompile += %w[email.css]

--- a/spec/railsapps/rails_52/app/mailers/auto_mailer.rb
+++ b/spec/railsapps/rails_52/app/mailers/auto_mailer.rb
@@ -14,8 +14,9 @@ class AutoMailer < ActionMailer::Base
   end
 
   private
+
   def roadie_options
-    unless action_name =~ /disabled/
+    unless /disabled/.match?(action_name)
       super.combine(url_options: {protocol: "https"})
     end
   end

--- a/spec/railsapps/rails_52/app/mailers/mailer.rb
+++ b/spec/railsapps/rails_52/app/mailers/mailer.rb
@@ -13,6 +13,7 @@ class Mailer < ActionMailer::Base
   end
 
   private
+
   def roadie_options
     super.combine(url_options: {protocol: "https"})
   end

--- a/spec/railsapps/rails_52/config/environments/production.rb
+++ b/spec/railsapps/rails_52/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
   # Disable serving static files from the `/public` folder by default since
@@ -49,7 +49,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -78,7 +78,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/spec/railsapps/rails_52/config/environments/test.rb
+++ b/spec/railsapps/rails_52/config/environments/test.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.

--- a/spec/railsapps/rails_52/config/initializers/assets.rb
+++ b/spec/railsapps/rails_52/config/initializers/assets.rb
@@ -10,4 +10,4 @@ Rails.application.config.assets.version = "1.0"
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( email.css )
+Rails.application.config.assets.precompile += %w[email.css]

--- a/spec/railsapps/rails_60/Gemfile
+++ b/spec/railsapps/rails_60/Gemfile
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
-source 'https://rubygems.org'
 
-gem 'rails', '~> 6.0.0'
-gem 'sass-rails'
-gem 'sprockets-rails'
-gem 'listen'
+source "https://rubygems.org"
 
-gem 'roadie-rails', path: '../../..'
+gem "rails", "~> 6.0.0"
+gem "sass-rails"
+gem "sprockets-rails"
+gem "listen"
+
+gem "roadie-rails", path: "../../.."

--- a/spec/railsapps/rails_60/Rakefile
+++ b/spec/railsapps/rails_60/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks

--- a/spec/railsapps/rails_60/bin/rails
+++ b/spec/railsapps/rails_60/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/spec/railsapps/rails_60/config.ru
+++ b/spec/railsapps/rails_60/config.ru
@@ -1,2 +1,2 @@
-require_relative 'config/environment'
+require_relative "config/environment"
 run Rails.application

--- a/spec/railsapps/rails_60/config/application.rb
+++ b/spec/railsapps/rails_60/config/application.rb
@@ -1,4 +1,4 @@
-require_relative 'boot'
+require_relative "boot"
 
 require "active_model/railtie"
 require "action_controller/railtie"
@@ -12,6 +12,6 @@ Bundler.require(*Rails.groups)
 module Rails60
   class Application < Rails::Application
     config.load_defaults 6.0
-    config.roadie.url_options = { host: 'example.app.org' }
+    config.roadie.url_options = {host: "example.app.org"}
   end
 end

--- a/spec/railsapps/rails_60/config/boot.rb
+++ b/spec/railsapps/rails_60/config/boot.rb
@@ -1,3 +1,3 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup'
+require "bundler/setup"

--- a/spec/railsapps/rails_60/config/environment.rb
+++ b/spec/railsapps/rails_60/config/environment.rb
@@ -1,2 +1,2 @@
-require_relative 'application'
+require_relative "application"
 Rails.application.initialize!

--- a/spec/railsapps/rails_60/config/environments/development.rb
+++ b/spec/railsapps/rails_60/config/environments/development.rb
@@ -2,12 +2,12 @@ Rails.application.configure do
   config.cache_classes = false
   config.eager_load = false
   config.consider_all_requests_local = true
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join("tmp", "caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-        'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false

--- a/spec/railsapps/rails_60/config/initializers/assets.rb
+++ b/spec/railsapps/rails_60/config/initializers/assets.rb
@@ -1,2 +1,2 @@
-Rails.application.config.assets.version = '1.0'
-Rails.application.config.assets.precompile += %w( email.css )
+Rails.application.config.assets.version = "1.0"
+Rails.application.config.assets.precompile += %w[email.css]

--- a/spec/railsapps/rails_61/Gemfile
+++ b/spec/railsapps/rails_61/Gemfile
@@ -1,10 +1,10 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'rails', '~> 6.1.0'
+gem "rails", "~> 6.1.0"
 
-gem 'bootsnap', '>= 1.4.4', require: false
-gem 'listen'
-gem 'sass-rails', '>= 6'
-gem 'sprockets-rails'
+gem "bootsnap", ">= 1.4.4", require: false
+gem "listen"
+gem "sass-rails", ">= 6"
+gem "sprockets-rails"
 
-gem 'roadie-rails', path: '../../..'
+gem "roadie-rails", path: "../../.."

--- a/spec/railsapps/rails_61/bin/rails
+++ b/spec/railsapps/rails_61/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
+APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"
 require "rails/commands"

--- a/spec/railsapps/rails_61/config/application.rb
+++ b/spec/railsapps/rails_61/config/application.rb
@@ -13,6 +13,6 @@ Bundler.require(*Rails.groups)
 module Rails61
   class Application < Rails::Application
     config.load_defaults 6.1
-    config.roadie.url_options = { host: "example.app.org" }
+    config.roadie.url_options = {host: "example.app.org"}
   end
 end

--- a/spec/railsapps/rails_61/config/boot.rb
+++ b/spec/railsapps/rails_61/config/boot.rb
@@ -1,4 +1,4 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup"
 require "bootsnap/setup"

--- a/spec/railsapps/rails_61/config/environments/development.rb
+++ b/spec/railsapps/rails_61/config/environments/development.rb
@@ -4,13 +4,13 @@ Rails.application.configure do
   config.cache_classes = false
   config.eager_load = false
   config.consider_all_requests_local = true
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join("tmp", "caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false

--- a/spec/railsapps/rails_61/config/initializers/assets.rb
+++ b/spec/railsapps/rails_61/config/initializers/assets.rb
@@ -1,2 +1,2 @@
-Rails.application.config.assets.version = '1.0'
-Rails.application.config.assets.precompile += %w( email.css )
+Rails.application.config.assets.version = "1.0"
+Rails.application.config.assets.precompile += %w[email.css]

--- a/spec/railsapps/rails_70/bin/bundle
+++ b/spec/railsapps/rails_70/bin/bundle
@@ -30,7 +30,7 @@ m = Module.new do
       if update_index && update_index.succ == i && a =~ Gem::Version::ANCHORED_VERSION_PATTERN
         bundler_version = a
       end
-      next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
+      next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/o
       bundler_version = $1
       update_index = i
     end
@@ -56,14 +56,14 @@ m = Module.new do
   def lockfile_version
     return unless File.file?(lockfile)
     lockfile_contents = File.read(lockfile)
-    return unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
+    return unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/o
     Regexp.last_match(1)
   end
 
   def bundler_requirement
     @bundler_requirement ||=
       env_var_version || cli_arg_version ||
-        bundler_requirement_for(lockfile_version)
+      bundler_requirement_for(lockfile_version)
   end
 
   def bundler_requirement_for(version)

--- a/spec/railsapps/rails_70/config/application.rb
+++ b/spec/railsapps/rails_70/config/application.rb
@@ -31,7 +31,7 @@ module Rails70
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
-    config.roadie.url_options = {host: 'example.app.org'}
+    config.roadie.url_options = {host: "example.app.org"}
     config.action_view.preload_links_header = false
   end
 end

--- a/spec/railsapps/rails_70/config/initializers/assets.rb
+++ b/spec/railsapps/rails_70/config/initializers/assets.rb
@@ -10,4 +10,4 @@ Rails.application.config.assets.version = "1.0"
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-Rails.application.config.assets.precompile += %w( email.css )
+Rails.application.config.assets.precompile += %w[email.css]

--- a/spec/railsapps/shared/all/app/mailers/auto_mailer.rb
+++ b/spec/railsapps/shared/all/app/mailers/auto_mailer.rb
@@ -14,8 +14,9 @@ class AutoMailer < ActionMailer::Base
   end
 
   private
+
   def roadie_options
-    unless action_name =~ /disabled/
+    unless /disabled/.match?(action_name)
       super.combine(url_options: {protocol: "https"})
     end
   end

--- a/spec/railsapps/shared/all/app/mailers/mailer.rb
+++ b/spec/railsapps/shared/all/app/mailers/mailer.rb
@@ -13,6 +13,7 @@ class Mailer < ActionMailer::Base
   end
 
   private
+
   def roadie_options
     super.combine(url_options: {protocol: "https"})
   end

--- a/spec/support/fake_mail.rb
+++ b/spec/support/fake_mail.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "mail"
+
+class FakeMail < Mail::Message
+  def delivered?
+    @delivered
+  end
+
+  def deliver
+    @delivered = true
+  end
+
+  def deliver!
+    @delivered = true
+  end
+end

--- a/spec/support/fake_pipeline.rb
+++ b/spec/support/fake_pipeline.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class FakePipeline
+  # Interface
+  def [](name)
+    @files.find { |file| file.matching_name == name }
+  end
+
+  ### Test helpers ###
+
+  def initialize
+    @files = []
+  end
+
+  def add_asset(matching_name, path, content)
+    @files << AssetFile.new(matching_name, path, content)
+  end
+
+  AssetFile = Struct.new(:matching_name, :pathname, :to_s)
+  private_constant :AssetFile
+end

--- a/spec/support/have_styling_matcher.rb
+++ b/spec/support/have_styling_matcher.rb
@@ -49,9 +49,11 @@ class StylingExpectation
   end
 
   protected
+
   attr_reader :rules
 
   private
+
   def parse_rules(css)
     css.split(";").map { |property| parse_property(property) }
   end

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -31,7 +31,7 @@ class RailsApp
     Mail.read_from_string(result)
   end
 
-  def read_delivered_email( # rubocop:disable Metrics/MethodLength
+  def read_delivered_email(
     mail_name,
     options = {}
   )


### PR DESCRIPTION
Let's make the code look a little more modern and make it easier to work with for people that are using editors with LSPs and smart formatters.

Standardrb is the formatter closest to my own personal preferences for Ruby, and is also very opinionated with little configuration, which removes the bike-shedding discussions. Further, it undoes a lot of madness from Rubucop that still baffles me several years later.