### PR TITLE
Fix propshaft shorter digest test error

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -121,7 +121,7 @@ describe "Integrations" do
         ).at_selector("body")
 
         expected_image_url =
-          "https://example.app.org/assets/rails-fbe4356d4aa42b95f211236439f3e675a5f9a7e6.png"
+          "https://example.app.org/assets/rails-fbe4356d.png"
 
         expect(document).to have_styling(
           "background" => "url(\"#{expected_image_url}\")"
@@ -154,7 +154,7 @@ describe "Integrations" do
         ).at_selector("body")
 
         expected_image_url =
-          "https://example.app.org/assets/rails-fbe4356d4aa42b95f211236439f3e675a5f9a7e6.png"
+          "https://example.app.org/assets/rails-fbe4356d.png"
 
         expect(document).to have_styling(
           "background" => "url(\"#{expected_image_url}\")"


### PR DESCRIPTION
Propshaft changed to have shorter digest here: https://github.com/rails/propshaft/pull/173

When I added support for propshaft I added tests that check the correct digested images are inlined.
With this PR I update the digests that now are expected.

This fixes [the CI tests. ](https://github.com/Mange/roadie-rails/actions/runs/9326040234) 