### PR TITLE
Fix compatibility with Propshaft 1.3.0

### DIFF
--- a/lib/roadie/rails/railtie.rb
+++ b/lib/roadie/rails/railtie.rb
@@ -13,12 +13,12 @@ module Roadie
         ]
 
         if app.config.respond_to?(:assets) && app.config.assets
-          if app.assets
+          if app.assets && app.assets.class.name != "Propshaft::Assembly"
             config.roadie.asset_providers << AssetPipelineProvider.new(app.assets)
-          elsif defined?(Propshaft)
-            config.after_initialize do |app|
-              config.roadie.asset_providers << AssetPropshaftProvider.new(app.assets)
-            end
+          elsif defined?(Propshaft) && app.assets.is_a?(Propshaft::Assembly)
+            # Initialize AssetPropshaftProvider immediately for Propshaft 1.3.0+ compatibility
+            # The after_initialize block was not executing correctly in Propshaft 1.3.0
+            config.roadie.asset_providers << AssetPropshaftProvider.new(app.assets)
           else
             app.config.assets.configure do |env|
               config.roadie.asset_providers <<

--- a/lib/roadie/rails/railtie.rb
+++ b/lib/roadie/rails/railtie.rb
@@ -13,12 +13,12 @@ module Roadie
         ]
 
         if app.config.respond_to?(:assets) && app.config.assets
-          if app.assets && app.assets.class.name != "Propshaft::Assembly"
-            config.roadie.asset_providers << AssetPipelineProvider.new(app.assets)
-          elsif defined?(Propshaft) && app.assets.is_a?(Propshaft::Assembly)
+          if app.assets && defined?(Propshaft::Assembly) && app.assets.is_a?(Propshaft::Assembly)
             # Initialize AssetPropshaftProvider immediately for Propshaft 1.3.0+ compatibility
             # The after_initialize block was not executing correctly in Propshaft 1.3.0
             config.roadie.asset_providers << AssetPropshaftProvider.new(app.assets)
+          elsif app.assets
+            config.roadie.asset_providers << AssetPipelineProvider.new(app.assets)
           else
             app.config.assets.configure do |env|
               config.roadie.asset_providers <<


### PR DESCRIPTION
## Description

This PR fixes the issue reported in #118 where roadie-rails doesn't work correctly with Propshaft 1.3.0.

## Problem

The `config.after_initialize` block was not executing correctly with Propshaft 1.3.0, causing the `AssetPropshaftProvider` not to be initialized. This resulted in the error:

```
NoMethodError: undefined method '[]' for an instance of Propshaft::Assembly
```

## Solution

- Modified `railtie.rb` to properly detect `Propshaft::Assembly` instances
- Initialize `AssetPropshaftProvider` immediately instead of using the `after_initialize` block
- Added type checking to distinguish between Sprockets and Propshaft

## Changes

- `lib/roadie/rails/railtie.rb`: Improved Propshaft detection logic and provider initialization

## Testing

- ✅ Rails 8.0 tests with Propshaft pass correctly
- ✅ No linting errors introduced
- ✅ Solution is backward compatible

## References

- Issue #118: Propshaft 1.3.0 changes breaks it
- PR #119: Reference structure for documentation

Fixes #118